### PR TITLE
benchmark/radosbench.py: return 255 if no_version

### DIFF
--- a/benchmark/radosbench.py
+++ b/benchmark/radosbench.py
@@ -66,7 +66,11 @@ class Radosbench(Benchmark):
         stdout, _ = common.pdsh(settings.getnodes('head'), '%s -c %s -v' % (self.cmd_path, self.tmp_conf)).communicate()
         m = (re.findall("version (\d+)", stdout) or
              re.findall("version v(\d+)", stdout))
-        return int(m[0])
+        if m:
+            return int(m[0])
+        elif 'no_version' in stdout:
+            # ENABLE_GIT_VERSION is disabled, so return a random large number
+            return 255
 
     def run(self):
         super(Radosbench, self).run()


### PR DESCRIPTION
there is chance that developer compiles ceph with
ENABLE_GIT_VERSION=OFF, in that case `no_version` is printed in the
place of version number in the output of `rados -v`. so "255" is
returned in that case. as it should be large enough to cover the
features we want to use in radosbench.

Signed-off-by: Kefu Chai <kchai@redhat.com>